### PR TITLE
Fix admin upload folder creation

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,11 +75,12 @@ def login():
 def admin():
     if not is_admin():
         return redirect(url_for('login'))
-    
+
     form = BolsaForm()
     if form.validate_on_submit():
         imagem = form.imagem.data
         if imagem and allowed_file(imagem.filename):
+            os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
             filename = secure_filename(imagem.filename)
             filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
             imagem.save(filepath)


### PR DESCRIPTION
## Summary
- ensure upload directory exists in `admin()` before saving files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842206ae9f8832ba01c3f3a8e0e6cd5